### PR TITLE
SSB signals

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -61,7 +61,7 @@ jobs:
           pip install -e .          
       - name: Test with pytest
         run: |
-          pytest tests/*
+          pytest --ignore=tests/matlab tests/
 
   pypi:
     needs: build  

--- a/py3gpp/nrPSS.py
+++ b/py3gpp/nrPSS.py
@@ -2,7 +2,7 @@ import numpy as np
 from py3gpp.helper import _calc_m_seq
 
 def nrPSS(ncellid):
-    assert ncellid <= 2, "invalid ncellid"
+    assert ncellid >= 0 and ncellid <= 1007, "invalid ncellid"
     N = 7
     c = [0, 1, 1, 0, 1, 1, 1]
     taps = [0, 4]

--- a/py3gpp/nrPSS.py
+++ b/py3gpp/nrPSS.py
@@ -3,9 +3,10 @@ from py3gpp.helper import _calc_m_seq
 
 def nrPSS(ncellid):
     assert ncellid >= 0 and ncellid <= 1007, "invalid ncellid"
+    N_id_2 = ncellid % 3
     N = 7
     c = [0, 1, 1, 0, 1, 1, 1]
     taps = [0, 4]
     m = _calc_m_seq(N, c, taps)
-    d_PSS = 1 - 2 * np.roll(m, -43*ncellid)
+    d_PSS = 1 - 2 * np.roll(m, -43*N_id_2)
     return d_PSS

--- a/py3gpp/nrSSS.py
+++ b/py3gpp/nrSSS.py
@@ -15,6 +15,7 @@ def _gold(N_id_1, N_id_2):
 
 
 def nrSSS(ncellid):
+    assert ncellid >= 0 and ncellid <= 1007, "invalid ncellid"
     N_id_2 = ncellid % 3
     N_id_1 = (ncellid - N_id_2) // 3
     return _gold(N_id_1, N_id_2)

--- a/tests/matlab/test_nrPSS.py
+++ b/tests/matlab/test_nrPSS.py
@@ -17,9 +17,6 @@ def run_nr_pss(ncellid, eng):
     data = nrPSS(ncellid)
     indices = nrPSSIndices()
 
-    print(ref_data[0:8])
-    print(data[0:8])
-
     assert np.all(ref_data == data)
     assert np.all(indices == ref_ind)
 

--- a/tests/matlab/test_nrPSS.py
+++ b/tests/matlab/test_nrPSS.py
@@ -1,0 +1,33 @@
+import matlab.engine
+import itertools
+import numpy as np
+import pytest
+
+from py3gpp.nrPSS import nrPSS
+from py3gpp.nrPSSIndices import nrPSSIndices
+
+def run_nr_pss(ncellid, eng):
+    ref_data = eng.nrPSS(matlab.double(ncellid))
+    ref_data = np.array(list(itertools.chain(*ref_data)))
+
+    ref_ind = eng.nrPSSIndices()
+    ref_ind = np.array(list(itertools.chain(*ref_ind)))
+    ref_ind = np.array(ref_ind - 1)
+
+    data = nrPSS(ncellid)
+    indices = nrPSSIndices()
+
+    print(ref_data[0:8])
+    print(data[0:8])
+
+    assert np.all(ref_data == data)
+    assert np.all(indices == ref_ind)
+
+@pytest.mark.parametrize("ncellid", [0, 500, 1007])
+def test_nr_pss(ncellid):
+    eng = matlab.engine.connect_matlab()
+
+    try:
+        run_nr_pss(ncellid, eng)
+    finally:
+        eng.quit()

--- a/tests/matlab/test_nrSSS.py
+++ b/tests/matlab/test_nrSSS.py
@@ -1,0 +1,31 @@
+import matlab.engine
+import itertools
+import numpy as np
+import pytest
+
+from py3gpp.nrSSS import nrSSS
+from py3gpp.nrSSSIndices import nrSSSIndices
+
+def run_nr_sss(ncellid, eng):
+    ref_data = eng.nrSSS(matlab.double(ncellid))
+    ref_data = np.array(list(itertools.chain(*ref_data)))
+
+    ref_ind = eng.nrSSSIndices()
+    ref_ind = np.array(list(itertools.chain(*ref_ind)))
+    ref_ind = np.array(ref_ind - 1)
+
+    data = nrSSS(ncellid)
+    indices = nrSSSIndices()
+
+    assert (ref_data == data).all()
+    assert (indices == ref_ind).all()
+
+@pytest.mark.parametrize("ncellid", [0, 600, 1007])
+def test_nr_sss(ncellid):
+    eng = matlab.engine.connect_matlab()
+
+    try:
+        run_nr_sss(ncellid, eng)
+    finally:
+        eng.quit()
+


### PR DESCRIPTION
I started testbenches migration (previously developed and tested) to py3gpp modules and faced with failed tests. I dig a bit and found weird behavior of SSB block modules.

The print of test is:

```
py3gpp [ 1. -1. -1.  1. -1. -1. -1. -1.]
matlab [ 1 -1 -1  1 -1 -1 -1 -1]

py3gpp [-1. -1. -1. -1. -1. -1.  1.  1.]
matlab [ 1 -1 -1 -1  1 -1  1  1]

py3gpp [-1. -1. -1. -1. -1. -1.  1.  1.]
matlab [-1  1  1  1  1 -1  1 -1]
```
Last two has fallen.

So, I'm going to fix the things. Does it hurt your stuff in the other repo/project @catkira ?