### PR TITLE
fixed return array type for empty PDSCH PTRS

### DIFF
--- a/py3gpp/nrPDSCHPTRSIndices.py
+++ b/py3gpp/nrPDSCHPTRSIndices.py
@@ -9,7 +9,7 @@ from py3gpp.configs.nrCarrierConfig import nrCarrierConfig
 
 def nrPDSCHPTRSIndices(carrier: nrCarrierConfig, cfg: nrPDSCHConfig):
     if cfg.EnablePTRS == 0:
-        return []
+        return np.array([])
 
     frame_begin = cfg.NRBSize * min(cfg.PRBSet)
     frame_end = cfg.NRBSize * (max(cfg.PRBSet)+1)


### PR DESCRIPTION
It could be a reason of exception raising in downstream processing