### PR TITLE
pre-commit flow for CI and standalone run

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -7,7 +7,23 @@ on:
     types: [created]
 
 jobs:
-  lint:
+  lint-pre-commit:
+      runs-on: ubuntu-latest
+      name: pre-commit
+      steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run -a
+
+  lint-quality:
+    needs: lint-pre-commit
+
     if: github.ref == 'refs/heads/master'
 
     permissions:
@@ -55,6 +71,8 @@ jobs:
         continue-on-error: true
 
   build:
+    needs: lint-pre-commit
+
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+exclude: |
+    (?x)^(
+        tests/test_data/.*|
+        examples/.*|
+        py3gpp/codes/.*
+    )$
+
+repos:
+- repo: "https://github.com/psf/black"
+  rev: "23.3.0"
+  hooks:
+  - id: "black"
+
+- repo: "https://github.com/pycqa/isort"
+  rev: "5.12.0"
+  hooks:
+  - id: "isort"
+    args:
+    - "--profile=black"
+
+- repo: "https://github.com/pycqa/flake8"
+  rev: "6.0.0"
+  hooks:
+  - id: "flake8"
+
+- repo: "https://github.com/pre-commit/pre-commit-hooks"
+  rev: "v4.4.0"
+  hooks:
+  - id: "trailing-whitespace"
+  - id: "mixed-line-ending"
+    args:
+    - "--fix=lf"
+  - id: "end-of-file-fixer"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See Matlab documentation of equivalent function
 ## Formatting
 * Screen width 120
 * spaces on each side of math operators like +-*/
+* run `pre-commit run -a` before any push. Otherwise PR will be rejected
 ## Testing
 * Each function must have a hard-coded test that can run on CI
 * Each function should have a Matlab test that can run on a machine with Matlab license

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ anybadge
 pytest
 pytest-xdist
 importlib_resources
+pre-commit


### PR DESCRIPTION
More contributors are here and I bring pre-commit formatter to CI to keep code in the same style. I think this might be useful for such a project. But we need to format WHOLE THE CODE.

So, I decided to leave this responsibility to @catkira as an owner and main contributor :) From my point it's better to include formatting as early as possible, otherwise it will be more and more painful.

I see several steps:
1. Format the whole code with `pre-commit run -a`
1.1 There are several `exclude` folders, and they won't affected
2. Push this massive change to repos
3. Check if `pre-commit` CI hooks works fine

I checked all of them, but we need to check hat everything is smooth in the main repo (here).

PS. The exact rules is point for discussion or modification. I've bring more or less default styles partially from `cocotb` CI flow.