### PR TITLE
fix(pdsch)

### DIFF
--- a/py3gpp/configs/DMRSConfigBase.py
+++ b/py3gpp/configs/DMRSConfigBase.py
@@ -5,7 +5,7 @@ class DMRSConfigBase():
         self._Ports = None
         self._DMRSTypeAPosition = 2
         self._DMRSAdditionalPosition = 0
-        self._DMRSLength = 0
+        self._DMRSLength = 1
         self._CustomSymbolSet = []
         self._DMRSPortSet = []
         self._NIDNSCID = []

--- a/py3gpp/nrPDSCHDMRSIndices.py
+++ b/py3gpp/nrPDSCHDMRSIndices.py
@@ -5,11 +5,15 @@ import numpy as np
 
 from py3gpp.nrPDSCHDMRS import PDSCHDMRSSyms
 from py3gpp.configs.nrPDSCHConfig import nrPDSCHConfig
+from py3gpp.configs.nrCarrierConfig import nrCarrierConfig
 
-def nrPDSCHDMRSIndices(cfg: nrPDSCHConfig):
-    frame_begin = cfg.NRBSize * min(cfg.PRBSet)
-    frame_end = cfg.NRBSize * (max(cfg.PRBSet)+1)
-    frame_size = cfg.NRBSize * cfg.NSizeBWP
+def nrPDSCHDMRSIndices(carrier: nrCarrierConfig, cfg: nrPDSCHConfig):
+    NRBSize = carrier.NStartGrid if not cfg.NRBSize else cfg.NRBSize
+    NSizeBWP = carrier.NSizeGrid if not cfg.NSizeBWP else cfg.NSizeBWP
+
+    frame_begin = NRBSize * min(cfg.PRBSet)
+    frame_end = NRBSize * (max(cfg.PRBSet)+1)
+    frame_size = NRBSize * NSizeBWP
 
     # Single frame DMRS positions
     dmrs_full_range = np.array(list(range(frame_begin, frame_end)))

--- a/tests/matlab/test_nrPDSCHDMRSIndices.py
+++ b/tests/matlab/test_nrPDSCHDMRSIndices.py
@@ -5,9 +5,12 @@ import numpy as np
 import pytest
 
 from py3gpp.nrPDSCHDMRSIndices import nrPDSCHDMRSIndices
+from py3gpp.configs.nrCarrierConfig import nrCarrierConfig
 from py3gpp.configs.nrPDSCHConfig import nrPDSCHConfig
 
 def run_nr_pdschdmrs_indices(cfg, eng):
+    carrier = nrCarrierConfig();
+
     pdsch_cfg = nrPDSCHConfig()
     pdsch_cfg.NSizeBWP = cfg['n_size_bwp']
     pdsch_cfg.NStartBWP = cfg['n_start_bwp']
@@ -21,7 +24,7 @@ def run_nr_pdschdmrs_indices(cfg, eng):
     pdsch_cfg.PRBSet = cfg['PRBSet']
     pdsch_cfg.SymbolAllocation = cfg['SymbolAllocation']
 
-    pdschdmrs_indices = nrPDSCHDMRSIndices(pdsch_cfg)
+    pdschdmrs_indices = nrPDSCHDMRSIndices(carrier, pdsch_cfg)
 
     [_, indices_ref, _, _] = eng.gen_pdschdmrs(cfg, nargout=4)
     indices_ref = np.array(list(itertools.chain(*indices_ref)))

--- a/tests/test_nrPDSCHDMRSIndices.py
+++ b/tests/test_nrPDSCHDMRSIndices.py
@@ -6,12 +6,15 @@ import sys
 
 from py3gpp.nrPDSCHDMRSIndices import nrPDSCHDMRSIndices
 from py3gpp.configs.nrPDSCHConfig import nrPDSCHConfig
+from py3gpp.configs.nrCarrierConfig import nrCarrierConfig
 
 sys.path.append("test_data")
 
 from test_data.pdsch import pdschdmrs_indices_ref
 
 def run_nr_pdschdmrs(cfg):
+    carrier = nrCarrierConfig();
+
     pdsch_cfg = nrPDSCHConfig();
     pdsch_cfg.NSizeBWP = cfg['n_size_bwp']
     pdsch_cfg.NStartBWP = cfg['n_start_bwp']
@@ -25,7 +28,7 @@ def run_nr_pdschdmrs(cfg):
     pdsch_cfg.PRBSet = cfg['PRBSet']
     pdsch_cfg.SymbolAllocation = cfg['SymbolAllocation']
 
-    pdschdmrs_indices = nrPDSCHDMRSIndices(pdsch_cfg)
+    pdschdmrs_indices = nrPDSCHDMRSIndices(carrier, pdsch_cfg)
 
     # Cut neccesary part of reference indices
     # TODO: now it works only for 0 and 3 symbols. 1 and 2 quite tricky to cut...

--- a/tests/testcases/test_66.py
+++ b/tests/testcases/test_66.py
@@ -1,0 +1,6 @@
+from py3gpp import nrPDSCHDMRSIndices, nrPDSCHConfig, nrCarrierConfig
+
+def test_issue_66():
+  cfg = nrPDSCHConfig()
+  carrier = nrCarrierConfig()
+  dmrsIndices = nrPDSCHDMRSIndices(carrier, cfg)


### PR DESCRIPTION
there was missing `carrier` argument in `nrPDSCHDMRSIndices`. Aligned with MATLAB defaults. Also added MATLAB default value to `DMRSLength`. Closes #66.