### PR TITLE
fix(nrPDSCHDMRS): gate 8/9-symbol additional DMRS on DMRSAdditionalPo…

### DIFF
--- a/py3gpp/nrPDSCHDMRS.py
+++ b/py3gpp/nrPDSCHDMRS.py
@@ -47,7 +47,8 @@ def PDSCHDMRSSyms(cfg: nrPDSCHConfig):
     occupied_syms = np.append(occupied_syms, typeA_pos)
 
     if sym_alloc in [8, 9]:
-        occupied_syms = np.append(occupied_syms, 7)
+        if add_pos >= 1:
+            occupied_syms = np.append(occupied_syms, 7)
     elif sym_alloc in [10, 11]:
         if add_pos == 1:
             occupied_syms = np.append(occupied_syms, 9)


### PR DESCRIPTION
Fixes #83 

PDSCHDMRSSyms() appended an extra DMRS at symbol 7 for any 8- or 9-symbol PDSCH allocation, regardless of DMRSAdditionalPosition. When DMRSAdditionalPosition == 0 the type A single-symbol DMRS must contain only the front-loaded symbol l0, but the function returned two symbols.

All other duration branches (10/11, 12, 13/14) already gate the additional DMRS on add_pos; the [8, 9] branch was missing that check. Add the `if add_pos >= 1` guard so the result matches 3GPP TS 38.211 Table 7.4.1.1.2-3.

This also corrects the downstream APIs that rely on PDSCHDMRSSyms: nrPDSCHDMRSIndices, nrPDSCHDMRS, nrPDSCHIndices and nrPDSCHPTRS.